### PR TITLE
Fix date API error

### DIFF
--- a/MensaDresden/API/OpenMensa.swift
+++ b/MensaDresden/API/OpenMensa.swift
@@ -44,6 +44,7 @@ class MealService: ObservableObject {
 
     let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter
     }()


### PR DESCRIPTION
This should fix a bug displaying only empty meal lists to users with a non-Gregorian calendar as standard (hi there 🙃) by setting the locale of the date formatter to american date formats.

I tested the fix with the iOS Simulator and was able to fix the bug there. 