### PR TITLE
Optimize handling of sold out meals & few other tweaks

### DIFF
--- a/MensaDresden/API/API.swift
+++ b/MensaDresden/API/API.swift
@@ -88,6 +88,7 @@ class API: ObservableObject {
         // Sort meals
         if case .success(let meals) = previousResult.result {
             let sortedMeals = meals.sorted(by: Self.mealComparator())
+                .sorted { !($0.isSoldOut ?? false) && ($1.isSoldOut ?? false) }
             previousResult.result = .success(sortedMeals)
         }
 
@@ -124,7 +125,7 @@ class API: ObservableObject {
                 switch (lhs.isDinner, rhs.isDinner) {
                 case (true, true), (false, false):
                     // Both are good/bad and both are dinner or not, so we're sorting based on name
-                    return lhs.allergenStrippedTitle < rhs.allergenStrippedTitle
+                    return lhs.category < rhs.category
                 case (true, false):
                     // Dinner should be at bottom before 3pm, at top after
                     return currentTime > 15

--- a/MensaDresden/MealList/MealCell/MealCell.swift
+++ b/MensaDresden/MealList/MealCell/MealCell.swift
@@ -104,6 +104,8 @@ struct MealCell: View {
                     }.padding(.top, 5)
                 }
             }
+            .saturation((meal.isSoldOut ?? false) ? 0.2 : 1)
+            .opacity((meal.isSoldOut ?? false) ? 0.5 : 1)
             if (meal.isSoldOut ?? false) {
                 Text("meal.sold-out")
                     .font(.largeTitle)
@@ -111,7 +113,7 @@ struct MealCell: View {
                     .foregroundStyle(.red)
                     .padding()
                     .border(.red, width: 3)
-                    .opacity(0.6)
+                    .opacity(0.8)
                     .rotationEffect(.degrees(-10))
             }
         }

--- a/MensaDresdenWatch WatchKit Extension/MealList/MealCell.swift
+++ b/MensaDresdenWatch WatchKit Extension/MealList/MealCell.swift
@@ -29,49 +29,64 @@ struct MealCell: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        ZStack {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(meal.category)
                     .font(Font.caption.smallCaps())
                     .foregroundColor(.gray)
-
-            Text(meal.allergenStrippedTitle)
-                .lineLimit(5)
-
-            ForEach(meal.diet, id: \.self) { diet in
-                Text(LocalizedStringKey(String(describing: diet)))
-                    .font(Font.caption.smallCaps())
-                    .bold()
-                    .foregroundColor(.green)
-                    .lineLimit(1)
+                
+                Text(meal.allergenStrippedTitle)
+                    .lineLimit(5)
+                
+                ForEach(meal.diet, id: \.self) { diet in
+                    Text(LocalizedStringKey(String(describing: diet)))
+                        .font(Font.caption.smallCaps())
+                        .bold()
+                        .foregroundColor(.green)
+                        .lineLimit(1)
+                }
+                
+                HStack(spacing: 8) {
+                    
+                    ZStack(alignment: .bottomLeading) {
+                        if settings.priceTypeIsStudent {
+                            PriceLabel(price: meal.prices?.students, shadow: 2)
+                                .padding(.bottom, 4)
+                        } else {
+                            PriceLabel(price: meal.prices?.employees, shadow: 2)
+                                .padding(.bottom, 4)
+                        }
+                    }
+                    
+                    HStack {
+                        ForEach(meal.ingredients, id: \.rawValue) { ingredient in
+                            Text(ingredient.emoji)
+                                .font(.system(size: 20))
+                                .accessibility(label: Text(LocalizedStringKey(ingredient.rawValue)))
+                        }
+                        if meal.isDinner {
+                            Spacer()
+                            Image(systemName: "moon.fill")
+                                .font(.headline)
+                                .foregroundColor(.yellow)
+                                .accessibility(label: Text("meal.dinner"))
+                        }
+                    }
+                }.padding(.top, 5)
             }
-            
-            HStack(spacing: 8) {
-                
-                ZStack(alignment: .bottomLeading) {
-                    if settings.priceTypeIsStudent {
-                        PriceLabel(price: meal.prices?.students, shadow: 2)
-                            .padding(.bottom, 4)
-                    } else {
-                        PriceLabel(price: meal.prices?.employees, shadow: 2)
-                            .padding(.bottom, 4)
-                    }
-                }
-                
-                HStack {
-                    ForEach(meal.ingredients, id: \.rawValue) { ingredient in
-                        Text(ingredient.emoji)
-                            .font(.system(size: 20))
-                            .accessibility(label: Text(LocalizedStringKey(ingredient.rawValue)))
-                    }
-                    if meal.isDinner {
-                        Spacer()
-                        Image(systemName: "moon.fill")
-                            .font(.headline)
-                            .foregroundColor(.yellow)
-                            .accessibility(label: Text("meal.dinner"))
-                    }
-                }
-            }.padding(.top, 5)
+            .saturation((meal.isSoldOut ?? false) ? 0.2 : 1)
+            .opacity((meal.isSoldOut ?? false) ? 0.5 : 1)
+            if (meal.isSoldOut ?? false) {
+                Text("meal.sold-out")
+                    .font(.headline)
+                    .bold()
+                    .foregroundStyle(.red)
+                    .padding()
+                    .background(.black)
+                    .border(.red, width: 3)
+                    .opacity(0.8)
+                    .rotationEffect(.degrees(-10))
+            }
         }
         .compositingGroup()
         .opacity(passesFilters ? 1.0 : 0.5)


### PR DESCRIPTION
With the corresponding pr on kiliankoe/EmealKit#24, sold out meals should reappear correctly in the app. Together with the data fix, I've looked at the UI and would like to propose a few minor tweaks here.

Improved readability of sold out meals:
| Before | After |
|-------|------|
| <img width="399" height="162" alt="grafik" src="https://github.com/user-attachments/assets/50359e22-5c55-405b-865e-ea44c52b1358" /> | <img width="399" height="162" alt="grafik" src="https://github.com/user-attachments/assets/0906a40a-bc4b-4b4c-819f-53b17d1195c8" /> |

---
Fallback meal sorting based on `category` name instead of `allergenStrippedTitle` → leads to more logically organized groups ("Fertig 1, Fertig 2, Fertig 3")
<img width="300" alt="simulator_screenshot_B44B92DB-66DE-4EFB-B0EC-FFE693C818D6" src="https://github.com/user-attachments/assets/9ffd7e62-2ef3-4b88-9e76-3252cd02ff10" />

---
Sorting the entire list to display sold out meals below available ones. (could previously get pretty uninformative & messy for large canteens like Alte Mensa)
| Before | After |
|-------|-------|
| <img width="200" alt="simulator_screenshot_661AD471-300C-466F-9AE0-C3553B45CD19" src="https://github.com/user-attachments/assets/b5002ea0-922a-472b-bd54-afc47e5e04df" /> | <img width="200" alt="simulator_screenshot_43CDC4A3-C7D5-4446-8242-66A9F6B3DFF1" src="https://github.com/user-attachments/assets/64c14fab-7ac8-4481-8827-8e4b3e93ef72" /> |

---
Add the sold out information on apple watch. (was entirely missing previously)

<img width="300" alt="simulator_screenshot_946AFFC5-5A70-4030-B79F-47A4C2C7D4FE" src="https://github.com/user-attachments/assets/9634341c-a3d9-485e-93a6-0c32cc259e50" />

